### PR TITLE
[Il-Kan 21] feat : User, Work 엔티티 및 관련 enum 구현 , Repository 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/ILKAN-was.main.iml" filepath="$PROJECT_DIR$/.idea/modules/ILKAN-was.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/ILKAN-was.main.iml
+++ b/.idea/modules/ILKAN-was.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/src/main/java/com/ilkan/domain/entity/User.java
+++ b/src/main/java/com/ilkan/domain/entity/User.java
@@ -1,0 +1,32 @@
+package com.ilkan.domain.entity;
+
+import com.ilkan.domain.enums.Role;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 용 기본 생성자(보호)
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+
+    @Column(name = "phone_number" , nullable = false)
+    private String phoneNumber;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private Role role;
+}

--- a/src/main/java/com/ilkan/domain/entity/User.java
+++ b/src/main/java/com/ilkan/domain/entity/User.java
@@ -7,26 +7,36 @@ import lombok.*;
 @Entity
 @Table(name = "user")
 @Getter
-@Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 용 기본 생성자(보호)
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자
 @AllArgsConstructor
 @Builder
 public class User {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동증가
     @Column(name = "user_id")
     private Long id;
-
 
     @Column(name = "name", nullable = false)
     private String name;
 
-
     @Column(name = "phone_number" , nullable = false)
     private String phoneNumber;
-
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private Role role;
+
+    // ==== 변경 메서드 ====
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/ilkan/domain/entity/Work.java
+++ b/src/main/java/com/ilkan/domain/entity/Work.java
@@ -1,0 +1,51 @@
+package com.ilkan.domain.entity;
+
+import com.ilkan.domain.enums.Status;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "work")
+public class Work {
+
+    @Id
+    @Column(name = "task_id")
+    private Long id;
+
+    // 의뢰자 정보 (User와 다대일 관계 , 한명이 여러 일거리 등록)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id" , nullable = false)
+    private User requester;
+
+    @Column(nullable = false)
+    private String title; // 제목
+
+    @Column(nullable = false)
+    private String description; // 상세설명
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt; // 등록시간
+
+    @Column
+    private Long price; // 가격
+
+    @Column(name = "is_negotiable")
+    private Boolean isNegotiable; // 금액 협의 가능여부
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status; // 일거리 상태
+
+    @Column(name = "task_start" , nullable = false)
+    private LocalDateTime taskStart; // 일거리 시작시간
+    @Column(name = "task_end" , nullable = false)
+    private LocalDateTime taskEnd; // 일거리 마감시간
+
+}

--- a/src/main/java/com/ilkan/domain/entity/Work.java
+++ b/src/main/java/com/ilkan/domain/entity/Work.java
@@ -7,7 +7,6 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -16,12 +15,13 @@ import java.time.LocalDateTime;
 public class Work {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // id 자동 증가
     @Column(name = "task_id")
     private Long id;
 
     // 의뢰자 정보 (User와 다대일 관계 , 한명이 여러 일거리 등록)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "requester_id" , nullable = false)
+    @JoinColumn(name = "requester_id", nullable = false)
     private User requester;
 
     @Column(nullable = false)
@@ -39,13 +39,46 @@ public class Work {
     @Column(name = "is_negotiable")
     private Boolean isNegotiable; // 금액 협의 가능여부
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Status status; // 일거리 상태
 
-    @Column(name = "task_start" , nullable = false)
+    @Column(name = "task_start", nullable = false)
     private LocalDateTime taskStart; // 일거리 시작시간
-    @Column(name = "task_end" , nullable = false)
+
+    @Column(name = "task_end", nullable = false)
     private LocalDateTime taskEnd; // 일거리 마감시간
 
+    // ==== 변경 메서드 ====
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updatePrice(Long price) {
+        if (price != null && price < 0) {
+            throw new IllegalArgumentException("가격은 0 이상이어야 합니다.");
+        }
+        this.price = price;
+    }
+
+    public void updateIsNegotiable(Boolean isNegotiable) {
+        this.isNegotiable = isNegotiable;
+    }
+
+    public void updateStatus(Status status) {
+        // 상태 변경 로직(예: 완료 → 진행중 불가) 검증 가능
+        this.status = status;
+    }
+
+    public void updateTaskPeriod(LocalDateTime taskStart, LocalDateTime taskEnd) {
+        if (taskStart.isAfter(taskEnd)) {
+            throw new IllegalArgumentException("시작일은 마감일보다 이후일 수 없습니다.");
+        }
+        this.taskStart = taskStart;
+        this.taskEnd = taskEnd;
+    }
 }

--- a/src/main/java/com/ilkan/domain/enums/Role.java
+++ b/src/main/java/com/ilkan/domain/enums/Role.java
@@ -1,0 +1,12 @@
+package com.ilkan.domain.enums;
+
+public enum Role {
+    // 일반 사용자 (의뢰자, 수행자 등 일반 권한)
+    CLIENT,
+
+    // 수행자
+    PERFORMER,
+
+    // 건물주
+    OWNER
+}

--- a/src/main/java/com/ilkan/domain/enums/Status.java
+++ b/src/main/java/com/ilkan/domain/enums/Status.java
@@ -1,0 +1,10 @@
+package com.ilkan.domain.enums;
+
+// 일거리 상태
+public enum Status {
+    OPEN, // 모집중
+    ASSIGNED, // 배정됨
+    IN_PROGRESS, // 진행중
+    COMPLETED, // 완료됨
+    CANCELLED // 취소됨
+}

--- a/src/main/java/com/ilkan/domain/repository/UserRepository.java
+++ b/src/main/java/com/ilkan/domain/repository/UserRepository.java
@@ -1,0 +1,18 @@
+package com.ilkan.domain.repository;
+
+import com.ilkan.domain.entity.Work;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 내가 올린 일거리 보관함
+public interface UserRepository extends JpaRepository<Work, Long> {
+    /*
+     로그인한 사용자가 requester(의뢰자)인 일거리만 조회
+     스프링 데이터 JPA 메서드 네이밍 규칙 사용
+     @param requesterId 로그인한 사용자 ID (user.user_id)
+     @param pageable 페이징 정보
+     @return Page<Work> */
+
+    Page<Work> findByRequester_Id(Long requesterId, Pageable pageable);
+}

--- a/src/main/java/com/ilkan/domain/repository/WorkRepository.java
+++ b/src/main/java/com/ilkan/domain/repository/WorkRepository.java
@@ -1,0 +1,7 @@
+package com.ilkan.domain.repository;
+
+import com.ilkan.domain.entity.Work;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkRepository extends JpaRepository<Work,Long> {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #4

## 📝작업 내용
feat(domain): User, Work 엔티티 구현
- ERD 컬럼명 기준 매핑  
- User와 Work 간 다대일 관계 설정  
- 주요 필드 nullable 제약조건 적용  
- Enum 타입 필드 매핑 완료

feat(domain):  Role, Status enum 구현
- 일거리 상태(Status) enum 정의 (OPEN, ASSIGNED, IN_PROGRESS , COMPLETED, CANCELLED)  
- 사용자 역할(Role) enum 정의 (CLIENT, PERFORMER, OWNER)  
- 도메인 로직에서 사용할 상태 및 권한 구분 명확화  

=====================================================

## 📝작업 내용
- WorkRepository 생성
  - JpaRepository<Work, Long> 상속
  - 기본 CRUD 기능 제공

- MyRepository 생성
  - JpaRepository<Work, Long> 상속
  - findByRequesterId(Long requesterId, Pageable pageable) 메서드 추가

## 추가된 기능
- WorkRepository: 전체 작업 리스트 조회 및 단일 작업 CRUD 가능
- MyRepository: 로그인한 사용자(requesterId)가 등록한 작업 목록만 조회 가능 (페이지네이션 지원)

## 테스트 방법
1. H2 DB 환경에서 Work 엔티티 데이터 삽입
2. WorkRepository.findAll() 호출 시 모든 데이터가 반환되는지 확인
3. MyRepository.findByRequesterId() 호출 시 해당 의뢰자 데이터만 필터링되는지 확인

