### PR TITLE
[ILKAN-49] fix: 수행자 작업 조회 직렬화 및 상태 필터링 로직 수정

### DIFF
--- a/src/main/java/com/ilkan/controller/UserWorkController.java
+++ b/src/main/java/com/ilkan/controller/UserWorkController.java
@@ -1,6 +1,6 @@
 package com.ilkan.controller;
 
-import com.ilkan.domain.entity.Work;
+import com.ilkan.dto.workdto.WorkResponseDto;
 import com.ilkan.service.WorkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,27 +21,22 @@ public class UserWorkController {
 
     // 내가 등록한 일거리 조회 (의뢰자)
     @GetMapping("/upload")
-    public ResponseEntity<Page<Work>> getMyUploadedWorks(
+    public ResponseEntity<Page<WorkResponseDto>> getMyUploadedWorks(
             @RequestParam Long userId,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) // 정렬, 페이지 크기 기본값 제어
-            Pageable pageable) {
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        // 서비스 호출하여 페이징된 결과 조회
-        Page<Work> works = workService.getWorksByRequester(userId, pageable);
-        // 결과를 HTTP 200 OK와 함께 반환
-        return ResponseEntity.ok(works);
+        // 서비스 호출하여 DTO로 변환된 페이징 결과 조회
+        Page<WorkResponseDto> worksDto = workService.getWorksByRequester(userId, pageable);
+        return ResponseEntity.ok(worksDto);
     }
 
     // 내가 수행중인 일거리 조회 (수행자)
     @GetMapping("/doing")
-    public ResponseEntity<Page<Work>> doingWorksByPerformer(
+    public ResponseEntity<Page<WorkResponseDto>> doingWorksByPerformer(
             @RequestParam Long userId,
-            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
-            Pageable pageable) {
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<Work> works = workService.doingWorksByPerformer(userId, pageable);
-        return ResponseEntity.ok(works);
+        Page<WorkResponseDto> worksDto = workService.doingWorksByPerformer(userId, pageable);
+        return ResponseEntity.ok(worksDto);
     }
-
-
 }

--- a/src/main/java/com/ilkan/service/WorkService.java
+++ b/src/main/java/com/ilkan/service/WorkService.java
@@ -2,40 +2,29 @@ package com.ilkan.service;
 
 import com.ilkan.domain.entity.Work;
 import com.ilkan.domain.enums.Status;
+import com.ilkan.dto.workdto.WorkResponseDto;
 import com.ilkan.repository.WorkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-// WorkService.java
+
 @Service
 @RequiredArgsConstructor
 public class WorkService {
     private final WorkRepository workRepository;
 
-    // createdAt 기준 내림차순 등록한 작업 조회 ( 의뢰자 기준 )
-    public Page<Work> getWorksByRequester(Long requesterId, Pageable pageable) {
-        // pageable에 sort 기본값이 없는 경우를 대비해서 정렬 보정
-        if (pageable.getSort().isUnsorted()) {
-            pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                    Sort.by("createdAt").descending());
-        }
-
-        return workRepository.findByRequesterId(requesterId, pageable);
+    // 의뢰자로서 등록한 일거리 조회 (DTO 반환)
+    public Page<WorkResponseDto> getWorksByRequester(Long requesterId, Pageable pageable) {
+        Page<Work> works = workRepository.findByRequesterId(requesterId, pageable);
+        return works.map(WorkResponseDto::fromEntity);
     }
 
-    // createdAt 기준 내림차순 수행중인 작업 조회 ( 수행자 기준 )
-    public Page<Work> doingWorksByPerformer(Long performerId, Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) {
-            pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-                    Sort.by("createdAt").descending());
-        }
-
-        return workRepository.findByPerformerIdAndStatus(performerId, Status.IN_PROGRESS, pageable);
+    // 수행자로서 수행중인 일거리 조회 (DTO 반환)
+    public Page<WorkResponseDto> doingWorksByPerformer(Long performerId, Pageable pageable) {
+        Page<Work> works = workRepository.findByPerformerIdAndStatus(performerId, Status.IN_PROGRESS, pageable);
+        return works.map(WorkResponseDto::fromEntity);
     }
-
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #13 

## 📝작업 내용

- 수행자가 수행 중인 작업(/doing) 조회 시 직렬화 문제 해결
- Work → WorkResponseDto 변환 적용으로 순환 참조 및 JSON 변환 오류 방지
- performerId + Status.IN_PROGRESS 조건으로 필터링하여 정확한 데이터 조회 가능

