### PR TITLE
[ILKAN-110] feat : 내가 사용중인 건물 조회 엔티티구현

### DIFF
--- a/src/main/java/com/ilkan/domain/entity/Building.java
+++ b/src/main/java/com/ilkan/domain/entity/Building.java
@@ -1,0 +1,57 @@
+package com.ilkan.domain.entity;
+
+import com.ilkan.domain.enums.BuildingTag;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "building")
+public class Building {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "building_id")
+    private Long id; // 건물 id
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(name = "owner_id", nullable = false)
+    private User owner; // 건물주
+
+    @Column(name = "building_address", nullable = false)
+    private String buildingAddress; // 건물 주소
+
+    @Column(name = "is_legal", nullable = false)
+    private boolean islegal; // 법적 여부
+
+    @Column(name = "building_image", nullable = false)
+    private String buildingImage; // 건물 이미지
+
+    @Column(name = "building_region", nullable = false)
+    private String buildingRegion; // 건물 지역
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "building_tag", nullable = false)
+    private BuildingTag buildingTag; // 건물 태그
+
+    // ==== 변경 메서드 ====
+    public void updateOwner (User owner) {
+        this.owner = owner;
+    }
+
+    public void updateBuildingAddress (String buildingAddress) {
+        this.buildingAddress = buildingAddress;
+    }
+
+    public void updateIslegal (boolean islegal) { this.islegal = islegal; }
+
+    public void updateBuildingImage (String buildingImage) { this.buildingImage = buildingImage; }
+
+    public void updateBuildingRegion (String buildingRegion) { this.buildingRegion = buildingRegion; }
+    // 건물 태그수정 불가, 구현X
+}

--- a/src/main/java/com/ilkan/domain/entity/Reservation.java
+++ b/src/main/java/com/ilkan/domain/entity/Reservation.java
@@ -1,0 +1,52 @@
+package com.ilkan.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "reservation")
+public class Reservation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performer_id")
+    private User performer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "building_id")
+    private Building building;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(nullable = false)
+    private Boolean isAccepted; // 이용 승인여부
+
+    // ==== 변경 메서드 ====
+    public void updatePerformer(User performer) {
+        this.performer = performer;
+    }
+
+    public void updatePhoneNumber(Building building) {
+        this.building = building;
+    }
+
+    public void updateRole(LocalDateTime startTime) { this.startTime = startTime; }
+
+    public void updateProfileImage(LocalDateTime endTime) { this.endTime = endTime; }
+
+    public void updateBioBoolean (Boolean isAccepted) { this.isAccepted = isAccepted; }
+
+}

--- a/src/main/java/com/ilkan/domain/entity/User.java
+++ b/src/main/java/com/ilkan/domain/entity/User.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Entity
 @Table(name = "user")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 기본 생성자
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class User {
@@ -58,9 +58,7 @@ public class User {
         this.bio = bio;
     }
 
-    public void updatePortfolioUrl(String portfolioUrl) {
-        this.portfolioUrl = portfolioUrl;
-    }
+    public void updatePortfolioUrl(String portfolioUrl) { this.portfolioUrl = portfolioUrl; }
 
     public void updateOrganization(String organization) {
         this.organization = organization;

--- a/src/main/java/com/ilkan/domain/enums/BuildingStatus.java
+++ b/src/main/java/com/ilkan/domain/enums/BuildingStatus.java
@@ -1,0 +1,6 @@
+package com.ilkan.domain.enums;
+
+// 건물 상태
+public enum BuildingStatus {
+    IN_USE // 사용 중
+}

--- a/src/main/java/com/ilkan/domain/enums/BuildingTag.java
+++ b/src/main/java/com/ilkan/domain/enums/BuildingTag.java
@@ -1,0 +1,11 @@
+package com.ilkan.domain.enums;
+
+public enum BuildingTag {
+
+    OFFICE_SPACE,       // 1,2,3 묶음 (오피스/회의실/스터디룸)
+    PHOTO_STUDIO,       // 4 촬영 스튜디오
+    POPUP_STORE,        // 5 팝업스토어
+    PARTY_ROOM,         // 7 파티룸
+    RECORDING_STUDIO    // 12 녹음실/음악작업실
+
+}

--- a/src/main/java/com/ilkan/domain/enums/Status.java
+++ b/src/main/java/com/ilkan/domain/enums/Status.java
@@ -1,6 +1,6 @@
 package com.ilkan.domain.enums;
 
-// 상태
+// 일거리 상태
 public enum Status {
     OPEN, // 모집중
     ASSIGNED, // 배정됨

--- a/src/main/java/com/ilkan/domain/enums/Status.java
+++ b/src/main/java/com/ilkan/domain/enums/Status.java
@@ -1,6 +1,6 @@
 package com.ilkan.domain.enums;
 
-// 일거리 상태
+// 상태
 public enum Status {
     OPEN, // 모집중
     ASSIGNED, // 배정됨


### PR DESCRIPTION
## 📝작업 내용
- 건물 및 예약 엔티티 구현
- buildingStatus enum 추가
- 추후에 건물 상태가 사용중 말고도 필요하다면 추가 예정

## 참고사항
- Status enum을 공용으로 쓰려다가, 건물상태를 나타내는 enum을 깔끔하게 하나 더 만들었습니다.

## 💬리뷰 요구사항(선택)

- 팀원 요청으로 빠른 merge가 필요하여 엔티티 및 dto 구현 후 PR , merge