### PR TITLE
[ILKAN-110] feat : 수행자가 사용중인 공간 조회

### DIFF
--- a/src/main/java/com/ilkan/controller/UserBuildingController.java
+++ b/src/main/java/com/ilkan/controller/UserBuildingController.java
@@ -1,0 +1,34 @@
+package com.ilkan.controller;
+
+import com.ilkan.dto.reservationdto.UserBuildingResDto;
+import com.ilkan.service.UserBuildingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/my/buildings")
+@RequiredArgsConstructor
+public class UserBuildingController {
+
+    private final UserBuildingService userBuildingService;
+
+    @GetMapping("/using")
+    public ResponseEntity<Page<UserBuildingResDto>> getUsingBuildings(
+            @RequestHeader("X-Role") String roleHeader,
+            @PageableDefault(sort = "startTime", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<UserBuildingResDto> reservations = userBuildingService.findUsingBuildingsByPerformer(roleHeader, pageable);
+        if (reservations.isEmpty()) {
+            return ResponseEntity.ok().body(Page.empty());
+        }
+        return ResponseEntity.ok(reservations);
+    }
+}

--- a/src/main/java/com/ilkan/controller/UserWorkController.java
+++ b/src/main/java/com/ilkan/controller/UserWorkController.java
@@ -8,10 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/my/commissions")
@@ -22,21 +19,21 @@ public class UserWorkController {
     // 내가 등록한 일거리 조회 (의뢰자)
     @GetMapping("/upload")
     public ResponseEntity<Page<WorkResponseDto>> getMyUploadedWorks(
-            @RequestParam Long userId,
+            @RequestHeader("X-Role") String roleHeader,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         // 서비스 호출하여 DTO로 변환된 페이징 결과 조회
-        Page<WorkResponseDto> worksDto = workService.getWorksByRequester(userId, pageable);
+        Page<WorkResponseDto> worksDto = workService.getWorksByRequester(roleHeader, pageable);
         return ResponseEntity.ok(worksDto);
     }
 
     // 내가 수행중인 일거리 조회 (수행자)
     @GetMapping("/doing")
     public ResponseEntity<Page<WorkResponseDto>> doingWorksByPerformer(
-            @RequestParam Long userId,
+            @RequestHeader("X-Role") String roleHeader,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<WorkResponseDto> worksDto = workService.doingWorksByPerformer(userId, pageable);
+        Page<WorkResponseDto> worksDto = workService.doingWorksByPerformer(roleHeader, pageable);
         return ResponseEntity.ok(worksDto);
     }
 }

--- a/src/main/java/com/ilkan/domain/entity/Building.java
+++ b/src/main/java/com/ilkan/domain/entity/Building.java
@@ -20,7 +20,7 @@ public class Building {
     private Long id; // 건물 id
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Column(name = "owner_id", nullable = false)
+    @JoinColumn(name = "owner_id", nullable = false)
     private User owner; // 건물주
 
     @Column(name = "building_address", nullable = false)

--- a/src/main/java/com/ilkan/service/UserBuildingService.java
+++ b/src/main/java/com/ilkan/service/UserBuildingService.java
@@ -1,0 +1,22 @@
+package com.ilkan.service;
+
+import com.ilkan.domain.entity.Reservation;
+import com.ilkan.domain.enums.BuildingStatus;
+import com.ilkan.dto.reservationdto.UserBuildingResDto;
+import com.ilkan.repository.UserBuildingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserBuildingService {
+    // (수행자) 내가 사용중인 일칸조회
+    private final UserBuildingRepository userBuildingRepository;
+
+    public Page<UserBuildingResDto> getBuildingsByPerformerAndStatus(Long performerId, BuildingStatus status, Pageable pageable) {
+        Page<Reservation> reservations = userBuildingRepository.findByPerformerIdAndBuildingStatus(performerId, status, pageable);
+        return reservations.map(UserBuildingResDto::fromEntity);
+    }
+}

--- a/src/main/java/com/ilkan/service/UserBuildingService.java
+++ b/src/main/java/com/ilkan/service/UserBuildingService.java
@@ -12,11 +12,24 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserBuildingService {
-    // (수행자) 내가 사용중인 일칸조회
+
     private final UserBuildingRepository userBuildingRepository;
 
-    public Page<UserBuildingResDto> getBuildingsByPerformerAndStatus(Long performerId, BuildingStatus status, Pageable pageable) {
-        Page<Reservation> reservations = userBuildingRepository.findByPerformerIdAndBuildingStatus(performerId, status, pageable);
+    // // role 기반 수행자가 사용중인 공간 조회
+    public Page<UserBuildingResDto> findUsingBuildingsByPerformer(String role, Pageable pageable) {
+        Long performerId = getUserIdByRole(role);
+        Page<Reservation> reservations = userBuildingRepository.findByPerformerIdAndBuildingStatus(performerId, BuildingStatus.IN_USE, pageable);
         return reservations.map(UserBuildingResDto::fromEntity);
     }
+
+    // role → userId 매핑
+    private Long getUserIdByRole(String role) {
+        switch (role.toUpperCase()) {
+            case "REQUESTER": return 1L;
+            case "PERFORMER": return 2L;
+            case "OWNER": return 3L;
+            default: throw new IllegalArgumentException("Unknown role: " + role);
+        }
+    }
 }
+

--- a/src/main/java/com/ilkan/service/WorkService.java
+++ b/src/main/java/com/ilkan/service/WorkService.java
@@ -9,22 +9,34 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-
 @Service
 @RequiredArgsConstructor
 public class WorkService {
     private final WorkRepository workRepository;
 
-    // 의뢰자로서 등록한 일거리 조회 (DTO 반환)
-    public Page<WorkResponseDto> getWorksByRequester(Long requesterId, Pageable pageable) {
+    // role 기반 의뢰자가 등록한 작업 조회
+    public Page<WorkResponseDto> getWorksByRequester(String role, Pageable pageable) {
+        Long requesterId = getUserIdByRole(role);
         Page<Work> works = workRepository.findByRequesterId(requesterId, pageable);
         return works.map(WorkResponseDto::fromEntity);
     }
 
-    // 수행자로서 수행중인 일거리 조회 (DTO 반환)
-    public Page<WorkResponseDto> doingWorksByPerformer(Long performerId, Pageable pageable) {
+    // role 기반 수행자가 수행중인 작업 조회
+    public Page<WorkResponseDto> doingWorksByPerformer(String role, Pageable pageable) {
+        Long performerId = getUserIdByRole(role);
         Page<Work> works = workRepository.findByPerformerIdAndStatus(performerId, Status.IN_PROGRESS, pageable);
         return works.map(WorkResponseDto::fromEntity);
     }
+
+    // role → userId 매핑
+    private Long getUserIdByRole(String role) {
+        switch (role.toUpperCase()) {
+            case "REQUESTER": return 1L;
+            case "PERFORMER": return 2L;
+            case "OWNER": return 3L;
+            default: throw new IllegalArgumentException("Unknown role: " + role);
+        }
+    }
 }
+
 


### PR DESCRIPTION
## 📝작업 내용
- 수행자 ID와 페이징 정보를 받아 현재 사용 중인 공간 예약 목록을 조회하는 서비스 메서드 추가
- 예약 상태가 IN_USE인 공간만 필터링하여 반환
- 컨트롤러에서 /api/v1/my/buildings/using GET 엔드포인트로 페이징 처리된 예약 정보 응답
- 예약, 건물, 수행자 정보가 포함된 DTO를 활용하여 API 응답 데이터 구조 통일
