### PR TITLE
[ILKAN-64] 내가(수행자) 지원한 일거리 조회 API

### DIFF
--- a/src/main/java/com/ilkan/controller/UserWorkController.java
+++ b/src/main/java/com/ilkan/controller/UserWorkController.java
@@ -36,4 +36,15 @@ public class UserWorkController {
         Page<WorkResponseDto> worksDto = workService.doingWorksByPerformer(roleHeader, pageable);
         return ResponseEntity.ok(worksDto);
     }
+
+    // 내가 지원한 일거리 조회 (수행자)
+    @GetMapping("/applied")
+    public ResponseEntity<Page<WorkResponseDto>> getAppliedWorks(
+            @RequestHeader("X-Role") String roleHeader,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Page<WorkResponseDto> appliedWorks = workService.getAppliedWorksByPerformer(roleHeader, pageable);
+        return ResponseEntity.ok(appliedWorks);
+    }
+
 }

--- a/src/main/java/com/ilkan/domain/enums/Status.java
+++ b/src/main/java/com/ilkan/domain/enums/Status.java
@@ -3,6 +3,7 @@ package com.ilkan.domain.enums;
 // 일거리 상태
 public enum Status {
     OPEN, // 모집중
+    APPLY_TO, // 지원함
     ASSIGNED, // 배정됨
     IN_PROGRESS, // 진행중
     COMPLETED, // 완료됨

--- a/src/main/java/com/ilkan/repository/WorkRepository.java
+++ b/src/main/java/com/ilkan/repository/WorkRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WorkRepository extends JpaRepository<Work, Long> {
-    Page<Work> findByRequesterId(Long requesterId, Pageable pageable); // 내가 등록한 일거리조회
+    Page<Work> findByRequesterId(Long requesterId, Pageable pageable); // 내가(의뢰자) 등록한 일거리조회
 
-    Page<Work> findByPerformerIdAndStatus(Long performerId, Status status, Pageable pageable);// 내가 수행중인 일거리 조회
+    Page<Work> findByPerformerIdAndStatus(Long performerId, Status status, Pageable pageable);// 내가(수행자) 수행중인 일거리 조회 , 내가(수행자) 지원한 일거리 조회
 }

--- a/src/main/java/com/ilkan/service/WorkService.java
+++ b/src/main/java/com/ilkan/service/WorkService.java
@@ -14,17 +14,24 @@ import org.springframework.stereotype.Service;
 public class WorkService {
     private final WorkRepository workRepository;
 
-    // role 기반 의뢰자가 등록한 작업 조회
+    // 의뢰자가 등록한 작업 조회
     public Page<WorkResponseDto> getWorksByRequester(String role, Pageable pageable) {
         Long requesterId = getUserIdByRole(role);
         Page<Work> works = workRepository.findByRequesterId(requesterId, pageable);
         return works.map(WorkResponseDto::fromEntity);
     }
 
-    // role 기반 수행자가 수행중인 작업 조회
+    // 수행자가 수행중인 작업 조회
     public Page<WorkResponseDto> doingWorksByPerformer(String role, Pageable pageable) {
         Long performerId = getUserIdByRole(role);
         Page<Work> works = workRepository.findByPerformerIdAndStatus(performerId, Status.IN_PROGRESS, pageable);
+        return works.map(WorkResponseDto::fromEntity);
+    }
+
+    // 수행자가 지원한 작업 조회
+    public Page<WorkResponseDto> getAppliedWorksByPerformer(String role, Pageable pageable) {
+        Long performerId = getUserIdByRole(role);
+        Page<Work> works = workRepository.findByPerformerIdAndStatus(performerId, Status.APPLY_TO, pageable);
         return works.map(WorkResponseDto::fromEntity);
     }
 


### PR DESCRIPTION
## 📝작업 내용
- 일거리 상태 중 지원함이 필요하여, Status enum에 APPLY_TO 추가
`Page<Work> works = workRepository.findByPerformerIdAndStatus(performerId, Status.APPLY_TO, pageable);` 해당 코드를 통해 '지원함' 으로 필터링 가능하도록 하였습니다.
- 수행자가 지원한 일거리 조회 마찬가지로 controller에서 createdAt (등록시간) 기준 내림차순 정렬하였습니다.