### PR TITLE
[ILKAN-58] [ILKAN-71] 공간 예약 API, 공간 예약 취소 API 구현

### DIFF
--- a/src/main/java/com/ilkan/IlkanWasApplication.java
+++ b/src/main/java/com/ilkan/IlkanWasApplication.java
@@ -2,7 +2,9 @@ package com.ilkan;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class IlkanWasApplication {
 

--- a/src/main/java/com/ilkan/auth/RoleCheckInterceptor.java
+++ b/src/main/java/com/ilkan/auth/RoleCheckInterceptor.java
@@ -1,6 +1,7 @@
 package com.ilkan.auth;
 
 import com.ilkan.domain.enums.Role;
+import com.ilkan.exception.RoleExceptions;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/ilkan/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/ilkan/config/GlobalExceptionHandler.java
@@ -1,10 +1,13 @@
 package com.ilkan.config;
 
-import com.ilkan.auth.RoleExceptions;
+import com.ilkan.exception.ReservationExceptions;
+import com.ilkan.exception.RoleExceptions;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestControllerAdvice
@@ -18,4 +21,17 @@ public class GlobalExceptionHandler {
                 "message", e.getMessage()
         ));
     }
+
+    @ExceptionHandler(ReservationExceptions.Base.class)
+    public ResponseEntity<Map<String,Object>> handleReservation(ReservationExceptions.Base e,
+                                                                HttpServletRequest req) {
+        Map<String,Object> body = new LinkedHashMap<>();
+        body.put("code", e.code());
+        body.put("message", e.getMessage());
+        body.put("status", e.status().value());
+        body.put("path", req.getRequestURI());
+        body.put("timestamp", java.time.LocalDateTime.now().toString());
+        return ResponseEntity.status(e.status()).body(body);
+    }
+
 }

--- a/src/main/java/com/ilkan/controller/ReservationController.java
+++ b/src/main/java/com/ilkan/controller/ReservationController.java
@@ -1,0 +1,47 @@
+package com.ilkan.controller;
+
+import com.ilkan.auth.AllowedRoles;
+import com.ilkan.domain.enums.Role;
+import com.ilkan.dto.reservationdto.CreateReservationRequestDto;
+import com.ilkan.dto.reservationdto.OccupiedDayResponseDto;
+import com.ilkan.dto.reservationdto.ReservationResponseDto;
+import com.ilkan.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    // 수행자 건물 예약
+    @AllowedRoles(Role.PERFORMER)
+    @PostMapping("/reservations")
+    public ReservationResponseDto create(@RequestBody CreateReservationRequestDto req, @RequestHeader("X-Role") Role role) {
+        return reservationService.create(req, role);
+    }
+
+    // 예약 취소
+    @AllowedRoles({Role.PERFORMER, Role.OWNER})
+    @PostMapping("/reservations/{id}/cancel")
+    public void cancel(@PathVariable Long id,
+                       @RequestHeader("X-Role") Role role) {
+        reservationService.cancel(id, role);
+    }
+
+    // 점유일
+    @AllowedRoles(Role.PERFORMER)
+    @GetMapping("/reservations/{buildingId}/occupied-days")
+    public List<OccupiedDayResponseDto> occupiedDays(
+            @PathVariable Long buildingId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return reservationService.getOccupiedDays(buildingId, from, to);
+    }
+}

--- a/src/main/java/com/ilkan/domain/entity/Reservation.java
+++ b/src/main/java/com/ilkan/domain/entity/Reservation.java
@@ -1,6 +1,6 @@
 package com.ilkan.domain.entity;
 
-import com.ilkan.domain.enums.BuildingStatus;
+import com.ilkan.domain.enums.ReservationStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,12 +32,9 @@ public class Reservation {
     @Column(nullable = false)
     private LocalDateTime endTime;
 
-    @Column(nullable = false)
-    private Boolean isAccepted; // 이용 승인여부
-
     @Enumerated(EnumType.STRING)
-    @Column(name = "building_status", nullable = false)
-    private BuildingStatus buildingStatus;
+    @Column(name = "reservation_status", nullable = false)
+    private ReservationStatus reservationStatus;
 
     // ==== 변경 메서드 ====
     public void updatePerformer(User performerId) {
@@ -52,6 +49,20 @@ public class Reservation {
 
     public void updateProfileImage(LocalDateTime endTime) { this.endTime = endTime; }
 
-    public void updateBioBoolean (Boolean isAccepted) { this.isAccepted = isAccepted; }
+    public void toReserved() {
+        this.reservationStatus = ReservationStatus.RESERVED;
+    }
+    public void toInUse() {
+        if (reservationStatus == ReservationStatus.CANCELED || reservationStatus == ReservationStatus.COMPLETE) return;
+        this.reservationStatus = ReservationStatus.IN_USE;
+    }
+    public void toComplete() {
+        if (reservationStatus == ReservationStatus.CANCELED) return;
+        this.reservationStatus = ReservationStatus.COMPLETE;
+    }
+    public void cancel() {
+        if (reservationStatus == ReservationStatus.COMPLETE) return; // 필요 시 규칙 조정
+        this.reservationStatus = ReservationStatus.CANCELED;
+    }
 
 }

--- a/src/main/java/com/ilkan/domain/entity/ReservationDay.java
+++ b/src/main/java/com/ilkan/domain/entity/ReservationDay.java
@@ -1,0 +1,29 @@
+package com.ilkan.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name="reservation_day",
+        uniqueConstraints=@UniqueConstraint(name="uq_building_day", columnNames={"building_id","day"}))
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+public class ReservationDay {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="reservation_id", nullable=false)
+    private Long reservationId;
+
+    @Column(name="building_id", nullable=false)
+    private Long buildingId;
+
+    @Column(nullable=false)
+    private LocalDate day;
+}

--- a/src/main/java/com/ilkan/dto/reservationdto/CreateReservationRequestDto.java
+++ b/src/main/java/com/ilkan/dto/reservationdto/CreateReservationRequestDto.java
@@ -1,0 +1,38 @@
+package com.ilkan.dto.reservationdto;
+
+import com.ilkan.domain.entity.Building;
+import com.ilkan.domain.entity.Reservation;
+import com.ilkan.domain.entity.User;
+import com.ilkan.domain.enums.ReservationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateReservationRequestDto {
+
+    private Long buildingId;
+    private LocalDate checkInDate;   // 포함
+    private LocalDate checkOutDate;  // 제외
+
+    // 체크인 시간 : 15시, 체크아웃 시간 : 11시
+    public Reservation toEntity(User performer, Building building) {
+        LocalDateTime start = checkInDate.atTime(15, 0);
+        LocalDateTime end   = checkOutDate.atTime(11, 0);
+
+        return Reservation.builder()
+                .buildingId(building)
+                .performerId(performer)
+                .startTime(start)
+                .endTime(end)
+                .reservationStatus(ReservationStatus.RESERVED) // 생성 시 자동 확정(체크인 전 상태)
+                .build();
+    }
+}

--- a/src/main/java/com/ilkan/dto/reservationdto/OccupiedDayResponseDto.java
+++ b/src/main/java/com/ilkan/dto/reservationdto/OccupiedDayResponseDto.java
@@ -1,0 +1,28 @@
+package com.ilkan.dto.reservationdto;
+
+import com.ilkan.domain.entity.ReservationDay;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OccupiedDayResponseDto {
+    private Long buildingId;
+    private LocalDate day;
+
+    public static OccupiedDayResponseDto fromEntity(ReservationDay d) {
+        return OccupiedDayResponseDto.builder()
+                .buildingId(d.getBuildingId())
+                .day(d.getDay())
+                .build();
+    }
+
+    public static List<OccupiedDayResponseDto> fromEntities(List<ReservationDay> list) {
+        return list.stream().map(OccupiedDayResponseDto::fromEntity).toList();
+    }
+}

--- a/src/main/java/com/ilkan/dto/reservationdto/ReservationResponseDto.java
+++ b/src/main/java/com/ilkan/dto/reservationdto/ReservationResponseDto.java
@@ -1,0 +1,40 @@
+package com.ilkan.dto.reservationdto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ilkan.domain.entity.Reservation;
+import com.ilkan.domain.enums.ReservationStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReservationResponseDto {
+
+    private Long reservationId;
+    private Long buildingId;
+    private Long performerId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    private LocalDateTime startTime;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
+    private LocalDateTime endTime;
+    private ReservationStatus reservationStatus;
+
+    public static ReservationResponseDto fromEntity(Reservation r) {
+        return ReservationResponseDto.builder()
+                .reservationId(r.getId())
+                .buildingId(r.getBuildingId().getId())
+                .performerId(r.getPerformerId().getId())
+                .startTime(r.getStartTime())
+                .endTime(r.getEndTime())
+                .reservationStatus(r.getReservationStatus())
+                .build();
+    }
+
+}

--- a/src/main/java/com/ilkan/dto/reservationdto/UserBuildingResDto.java
+++ b/src/main/java/com/ilkan/dto/reservationdto/UserBuildingResDto.java
@@ -1,7 +1,7 @@
 package com.ilkan.dto.reservationdto;
 
 import com.ilkan.domain.entity.Reservation;
-import com.ilkan.domain.enums.BuildingStatus;
+import com.ilkan.domain.enums.ReservationStatus;
 import com.ilkan.dto.userdto.UserResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +20,7 @@ public class UserBuildingResDto {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private Boolean isAccepted;
-    private BuildingStatus buildingStatus;
+    private ReservationStatus reservationStatus;
 
     public static UserBuildingResDto fromEntity(Reservation reservation) {
         return UserBuildingResDto.builder()
@@ -30,8 +30,7 @@ public class UserBuildingResDto {
                 .buildingAddress(reservation.getBuildingId().getBuildingAddress())
                 .startTime(reservation.getStartTime())
                 .endTime(reservation.getEndTime())
-                .isAccepted(reservation.getIsAccepted())
-                .buildingStatus(reservation.getBuildingStatus())
+                .reservationStatus(reservation.getReservationStatus())
                 .build();
     }
 }

--- a/src/main/java/com/ilkan/exception/ReservationExceptions.java
+++ b/src/main/java/com/ilkan/exception/ReservationExceptions.java
@@ -1,0 +1,56 @@
+// com.ilkan.reservation.ReservationExceptions.java
+package com.ilkan.exception;
+
+import org.springframework.http.HttpStatus;
+
+public final class ReservationExceptions {
+    private ReservationExceptions() {}
+
+    public static abstract class Base extends RuntimeException {
+        public Base(String message) { super(message); }
+        public abstract String code();
+        public abstract HttpStatus status();
+    }
+
+    public static class BuildingNotFound extends Base {
+        public BuildingNotFound() { super("building not found"); }
+        @Override public String code() { return "BUILDING_NOT_FOUND"; }
+        @Override public HttpStatus status() { return HttpStatus.NOT_FOUND; }
+    }
+
+    public static class PerformerNotFound extends Base {
+        public PerformerNotFound() { super("performer not found"); }
+        @Override public String code() { return "PERFORMER_NOT_FOUND"; }
+        @Override public HttpStatus status() { return HttpStatus.NOT_FOUND; }
+    }
+
+    public static class InvalidRange extends Base {
+        public InvalidRange(String msg) { super(msg); }
+        @Override public String code() { return "INVALID_RANGE"; }
+        @Override public HttpStatus status() { return HttpStatus.BAD_REQUEST; }
+    }
+
+    public static class AlreadyOccupied extends Base {
+        public AlreadyOccupied() { super("해당 기간에 이미 예약이 있습니다."); }
+        @Override public String code() { return "RESERVATION_ALREADY_OCCUPIED"; }
+        @Override public HttpStatus status() { return HttpStatus.CONFLICT; }
+    }
+
+    public static class ReservationNotFound extends Base {
+        public ReservationNotFound() { super("reservation not found"); }
+        @Override public String code() { return "RESERVATION_NOT_FOUND"; }
+        @Override public HttpStatus status() { return HttpStatus.NOT_FOUND; }
+    }
+
+    public static class CancelNotAllowed extends Base {
+        public CancelNotAllowed(String msg) { super(msg); }
+        @Override public String code() { return "RESERVATION_CANCEL_NOT_ALLOWED"; }
+        @Override public HttpStatus status() { return HttpStatus.BAD_REQUEST; }
+    }
+
+    public static class Forbidden extends Base {
+        public Forbidden() { super("취소 권한이 없습니다."); }
+        @Override public String code() { return "FORBIDDEN"; }
+        @Override public HttpStatus status() { return HttpStatus.FORBIDDEN; }
+    }
+}

--- a/src/main/java/com/ilkan/exception/RoleExceptions.java
+++ b/src/main/java/com/ilkan/exception/RoleExceptions.java
@@ -1,4 +1,4 @@
-package com.ilkan.auth;
+package com.ilkan.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/ilkan/repository/BuildingRepository.java
+++ b/src/main/java/com/ilkan/repository/BuildingRepository.java
@@ -1,0 +1,16 @@
+package com.ilkan.repository;
+
+import com.ilkan.domain.entity.Building;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface BuildingRepository extends JpaRepository<Building, Long> {
+
+    // 동시성 제어용 (예약 생성 시)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select b from Building b where b.id = :id")
+    Optional<Building> findForUpdate(@Param("id") Long id);
+}

--- a/src/main/java/com/ilkan/repository/ReservationDayRepository.java
+++ b/src/main/java/com/ilkan/repository/ReservationDayRepository.java
@@ -1,0 +1,21 @@
+package com.ilkan.repository;
+
+import com.ilkan.domain.entity.ReservationDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReservationDayRepository extends JpaRepository<ReservationDay, Long> {
+
+    // 사전 체크용
+    boolean existsByBuildingIdAndDayBetween(Long buildingId, LocalDate from, LocalDate to);
+
+    void deleteByReservationId(Long reservationId);
+
+    // 점유일 달력 채우기
+    List<ReservationDay> findByBuildingIdAndDayBetweenOrderByDayAsc(
+            Long buildingId, LocalDate from, LocalDate to
+    );
+
+}

--- a/src/main/java/com/ilkan/repository/ReservationRepository.java
+++ b/src/main/java/com/ilkan/repository/ReservationRepository.java
@@ -1,0 +1,28 @@
+package com.ilkan.repository;
+
+import com.ilkan.domain.entity.Reservation;
+import com.ilkan.domain.enums.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    @Query("""
+      select r from Reservation r
+      where r.reservationStatus = com.ilkan.domain.enums.ReservationStatus.RESERVED
+        and r.startTime <= :now and r.endTime > :now
+    """)
+    List<Reservation> findToInUse(@Param("now") LocalDateTime now);
+
+    @Query("""
+      select r from Reservation r
+      where r.reservationStatus in (com.ilkan.domain.enums.ReservationStatus.RESERVED,
+                                    com.ilkan.domain.enums.ReservationStatus.IN_USE)
+        and r.endTime <= :now
+    """)
+    List<Reservation> findToComplete(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/ilkan/repository/UserBuildingRepository.java
+++ b/src/main/java/com/ilkan/repository/UserBuildingRepository.java
@@ -1,11 +1,13 @@
 package com.ilkan.repository;
 
 import com.ilkan.domain.entity.Reservation;
-import com.ilkan.domain.enums.BuildingStatus;
+import com.ilkan.domain.enums.ReservationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserBuildingRepository extends JpaRepository<Reservation, Long> {
-    Page<Reservation> findByPerformerIdAndBuildingStatus(Long performerId, BuildingStatus status, Pageable pageable);
+    Page<Reservation> findByPerformerId_IdAndReservationStatus(
+            Long performerId, ReservationStatus status, Pageable pageable);
+
 }

--- a/src/main/java/com/ilkan/repository/UserRepository.java
+++ b/src/main/java/com/ilkan/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package com.ilkan.repository;
 
 import com.ilkan.domain.entity.User;
+import com.ilkan.domain.enums.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findFirstByRole(Role role);
 }

--- a/src/main/java/com/ilkan/scheduler/ReservationStatusScheduler.java
+++ b/src/main/java/com/ilkan/scheduler/ReservationStatusScheduler.java
@@ -1,0 +1,33 @@
+package com.ilkan.scheduler;
+
+import com.ilkan.domain.entity.Reservation;
+import com.ilkan.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationStatusScheduler {
+
+    private final ReservationRepository reservationRepo;
+
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void tick() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+
+        // 1. IN_USE인 예약 목록 조회
+        List<Reservation> toInUse = reservationRepo.findToInUse(now);
+        toInUse.forEach(Reservation::toInUse);
+
+        // 2. COMPLETE인 예약 목록 조회
+        List<Reservation> toComplete = reservationRepo.findToComplete(now);
+        toComplete.forEach(Reservation::toComplete);
+    }
+}

--- a/src/main/java/com/ilkan/service/AuthService.java
+++ b/src/main/java/com/ilkan/service/AuthService.java
@@ -1,6 +1,6 @@
 package com.ilkan.service;
 
-import com.ilkan.auth.RoleExceptions;
+import com.ilkan.exception.RoleExceptions;
 import com.ilkan.domain.enums.Role;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/ilkan/service/ReservationService.java
+++ b/src/main/java/com/ilkan/service/ReservationService.java
@@ -1,0 +1,186 @@
+package com.ilkan.service;
+
+import com.ilkan.domain.enums.Role;
+import com.ilkan.exception.ReservationExceptions;
+import com.ilkan.domain.entity.ReservationDay;
+import com.ilkan.domain.entity.Building;
+import com.ilkan.domain.entity.Reservation;
+import com.ilkan.domain.entity.User;
+import com.ilkan.domain.enums.ReservationStatus;
+import com.ilkan.dto.reservationdto.CreateReservationRequestDto;
+import com.ilkan.dto.reservationdto.OccupiedDayResponseDto;
+import com.ilkan.dto.reservationdto.ReservationResponseDto;
+import com.ilkan.repository.BuildingRepository;
+import com.ilkan.repository.ReservationDayRepository;
+import com.ilkan.repository.ReservationRepository;
+import com.ilkan.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReservationService {
+
+    private final BuildingRepository buildingRepo;
+    private final UserRepository userRepo;
+    private final ReservationRepository reservationRepo;
+    private final ReservationDayRepository dayRepo;
+
+    /**
+     * 새로운 예약 생성
+     *
+     * - 요청에서 전달받은 체크인/체크아웃 날짜 검증
+     * - 예약 대상 건물과 수행자를 조회.
+     * - 해당 기간에 건물이 이미 점유되어 있는 경우 사전 점유 여부를 확인하여 예외 발생
+     * - 예약 정보를 저장하고, 체크인일부터 체크아웃 전날까지의 날짜를 {@code ReservationDay} 엔티티로 생성하여 저장
+     *
+     * @param req 예약 생성 요청 DTO
+     * @param role 예약 생성 요청자 역할
+     *
+     * @return 생성된 {@link Reservation} 정보를 담은 {@link ReservationResponseDto}.
+     *
+     * @throws com.ilkan.exception.ReservationExceptions.InvalidRange
+     *         체크인 또는 체크아웃 날짜가 {@code null}이거나, 체크아웃 날짜가 체크인 날짜와 같거나 이전인 경우
+     * @throws com.ilkan.exception.ReservationExceptions.BuildingNotFound
+     *         {@code buildingId}에 해당하는 건물이 존재하지 않는 경우
+     * @throws com.ilkan.exception.ReservationExceptions.PerformerNotFound
+     *         {@code performerId}에 해당하는 사용자가 존재하지 않는 경우.
+     * @throws com.ilkan.exception.ReservationExceptions.AlreadyOccupied
+     *         지정한 기간에 건물이 이미 예약되어 있는 경우
+     *
+     */
+    public ReservationResponseDto create(CreateReservationRequestDto req, Role role) {
+
+        if (req.getBuildingId() == null) {
+            throw new ReservationExceptions.BuildingNotFound();
+        }
+        validateRange(req.getCheckInDate(), req.getCheckOutDate());
+
+        Building building = buildingRepo.findForUpdate(req.getBuildingId())
+                .orElseThrow(ReservationExceptions.BuildingNotFound::new);
+
+        // role로 수행자 꺼내오기
+        if (role != Role.PERFORMER) {
+                throw new ReservationExceptions.Forbidden();
+        }
+        User performer = userRepo.findFirstByRole(Role.PERFORMER)
+                .orElseThrow(ReservationExceptions.PerformerNotFound::new);
+
+
+        // 1. 빠른 check
+        boolean occupied = dayRepo.existsByBuildingIdAndDayBetween(
+                req.getBuildingId(),
+                req.getCheckInDate(),
+                req.getCheckOutDate().minusDays(1) // [in, out) 규칙이면 out-1까지 체크
+        );
+        if (occupied) throw new ReservationExceptions.AlreadyOccupied();
+
+        // 2. 예약 생성
+        Reservation reservation = req.toEntity(performer, building);
+        reservationRepo.save(reservation);
+
+        // 3. reservationDay 벌크 저장
+        List<ReservationDay> days = new java.util.ArrayList<>();
+        for (LocalDate d = req.getCheckInDate(); d.isBefore(req.getCheckOutDate()); d = d.plusDays(1)) {
+            days.add(ReservationDay.builder()
+                    .reservationId(reservation.getId())
+                    .buildingId(building.getId())
+                    .day(d)
+                    .build());
+        }
+        try {
+            dayRepo.saveAll(days);
+        } catch (DataIntegrityViolationException e) {
+            throw new ReservationExceptions.AlreadyOccupied();
+        }
+
+        return ReservationResponseDto.fromEntity(reservation);
+    }
+
+    /**
+     * 예약 날짜 범위 점검
+     *
+     * @param from 시작 날짜 (포함)
+     * @param to 종료 날짜 (미포함)
+     *
+     * @throws com.ilkan.exception.ReservationExceptions.InvalidRange
+     *         날짜가 {@code null}이거나, 시작일이 종료일과 같거나 이후이거나,
+     *         시작일로부터 6개월을 초과하는 범위인 경우.
+     */
+    private void validateRange(LocalDate from, LocalDate to) {
+        if (from == null || to == null || !from.isBefore(to)) {
+            throw new ReservationExceptions.InvalidRange("invalid range");
+        }
+        if (from.plusMonths(6).isBefore(to)) { // 최대 6개월 같은 가드
+            throw new ReservationExceptions.InvalidRange("range too large (max 6 months)");
+        }
+    }
+
+    /**
+     * 지정 건물의 점유 일자 목록
+     *
+     * @param buildingId 점유 일자를 조회할 건물의 ID
+     * @param from 조회 시작 날짜
+     * @param to 조회 종료 날짜
+     * @return 점유 일자 목록을 담은 {@link OccupiedDayResponseDto} 리스트
+     *
+     *  @throws com.ilkan.exception.ReservationExceptions.InvalidRange
+     *          날짜 범위가 유효하지 않거나, 최대 허용 범위(6개월)를 초과하는 경우
+     *
+     */
+    @Transactional(readOnly = true)
+    public List<OccupiedDayResponseDto> getOccupiedDays(Long buildingId, LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        var days = dayRepo.findByBuildingIdAndDayBetweenOrderByDayAsc(buildingId, from, to);
+        return OccupiedDayResponseDto.fromEntities(days);
+    }
+
+    /**
+     * 예약 취소
+     *
+     * @param reservationId 취소할 예약의 ID
+     * @param role 예약 취소 요청자 역할
+     *
+     * @throws com.ilkan.exception.ReservationExceptions.ReservationNotFound
+     *         지정한 ID의 예약이 존재하지 않는 경우
+     * @throws com.ilkan.exception.ReservationExceptions.CancelNotAllowed
+     *         예약 상태가 IN_USE 또는 COMPLETE인 경우
+     * @throws com.ilkan.exception.ReservationExceptions.Forbidden
+     *         요청자가 수행자나 건물 소유자가 아닌 경우
+     */
+    public void cancel(Long reservationId, Role role) {
+        Reservation r = reservationRepo.findById(reservationId)
+                .orElseThrow(ReservationExceptions.ReservationNotFound::new);
+
+        // 1. 예약 취소 조건
+        if (r.getReservationStatus() == ReservationStatus.IN_USE) {
+            throw new ReservationExceptions.CancelNotAllowed("체크인 이후에는 취소할 수 없습니다.");
+        }
+        if (r.getReservationStatus() == ReservationStatus.COMPLETE) {
+            throw new ReservationExceptions.CancelNotAllowed("이미 이용이 완료된 예약입니다.");
+        }
+        if (r.getReservationStatus() == ReservationStatus.CANCELED) {
+            return;
+        }
+
+        // 2) performer 본인 예약 또는 해당 건물 owner여야 함
+        Long mappedRequesterId = switch (role) {
+            case PERFORMER -> r.getPerformerId().getId();           // 이 예약의 수행자
+            case OWNER     -> r.getBuildingId().getOwner().getId();  // 이 예약 건물의 소유자
+            default -> null;
+        };
+
+        if (mappedRequesterId == null) {
+            throw new ReservationExceptions.Forbidden();
+        }
+
+        r.cancel();
+        dayRepo.deleteByReservationId(reservationId);
+    }
+}

--- a/src/main/java/com/ilkan/service/UserBuildingService.java
+++ b/src/main/java/com/ilkan/service/UserBuildingService.java
@@ -1,7 +1,7 @@
 package com.ilkan.service;
 
 import com.ilkan.domain.entity.Reservation;
-import com.ilkan.domain.enums.BuildingStatus;
+import com.ilkan.domain.enums.ReservationStatus;
 import com.ilkan.dto.reservationdto.UserBuildingResDto;
 import com.ilkan.repository.UserBuildingRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ public class UserBuildingService {
     // // role 기반 수행자가 사용중인 공간 조회
     public Page<UserBuildingResDto> findUsingBuildingsByPerformer(String role, Pageable pageable) {
         Long performerId = getUserIdByRole(role);
-        Page<Reservation> reservations = userBuildingRepository.findByPerformerIdAndBuildingStatus(performerId, BuildingStatus.IN_USE, pageable);
+        Page<Reservation> reservations = userBuildingRepository.findByPerformerId_IdAndReservationStatus(performerId, ReservationStatus.IN_USE, pageable);
         return reservations.map(UserBuildingResDto::fromEntity);
     }
 


### PR DESCRIPTION
## 📝작업 내용

### 공간 예약 API 구현
- 건물 ID와 예약 기간(체크인·체크아웃 날짜) 기반으로 예약 생성
- `X-Role` 헤더로 전달된 역할이 `PERFORMER`인 경우 해당 사용자 자동 매핑
- 예약 가능 여부 검증 (기존 점유일 중복 시 예외 처리)
- 예약 생성 시 `ReservationDay` 벌크 저장 처리

### 공간 예약 취소 API 구현
- 예약 ID와 요청자 정보(X-Role, 필요 시 사용자 ID`) 기반으로 권한 검증
- **수행자 또는 건물주**만 예약 취소 가능
- 취소 시 예약 상태 및 관련 점유일 데이터 삭제/변경 처리

### 보완 사항
- `Reservation.isAccepted` 기본값 설정
- 중복 예약 방지 로직 추가 (`existsByBuildingIdAndDayBetween` 활용)
