### PR TITLE
[ILKAN-145] 의뢰자가 수행자 선택 API

### DIFF
--- a/src/main/java/com/ilkan/controller/UserWorkController.java
+++ b/src/main/java/com/ilkan/controller/UserWorkController.java
@@ -103,4 +103,16 @@ public class UserWorkController implements UserWorkApi {
         return ResponseEntity.ok(response);
     }
 
+    // 의뢰자기준 수행자 선택
+    @AllowedRoles(Role.REQUESTER)
+    @PostMapping("/{taskId}/approve/{performerId}")
+    public ResponseEntity<WorkApplyListResDto> approvePerformer(
+            @RequestHeader("X-Role") String roleHeader, // 요청자 권한
+            @PathVariable Long taskId,
+            @PathVariable Long performerId) {
+
+        WorkApplyListResDto approvedPerformer = workService.approvePerformer(roleHeader, taskId, performerId);
+        return ResponseEntity.ok(approvedPerformer);
+    }
+
 }

--- a/src/main/java/com/ilkan/controller/api/UserWorkApi.java
+++ b/src/main/java/com/ilkan/controller/api/UserWorkApi.java
@@ -1,5 +1,7 @@
 package com.ilkan.controller.api;
 
+import com.ilkan.auth.AllowedRoles;
+import com.ilkan.domain.enums.Role;
 import com.ilkan.dto.workdto.ApplicationResDto;
 import com.ilkan.dto.workdto.WorkApplyDetailResDto;
 import com.ilkan.dto.workdto.WorkApplyListResDto;
@@ -177,14 +179,14 @@ public interface UserWorkApi {
             ),
             @ApiResponse(responseCode = "403", description = "권한 없음",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class),
-                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                            examples = @ExampleObject(value = """
                     {"code":"REQUESTER_FORBIDDEN","message":"의뢰자 권한이 없습니다.","status":403,
                      "path":"/api/v1/myprofile/commissions/{workId}/applies/{applyId}","timestamp":"2025-08-19T14:00:00Z"}""")
                     )
             ),
             @ApiResponse(responseCode = "404", description = "지원서 또는 일거리 없음",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class),
-                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                            examples = @ExampleObject(value = """
                     {"code":"APPLICATION_NOT_FOUND","message":"해당 지원서를 찾을 수 없습니다.","status":404,
                      "path":"/api/v1/myprofile/commissions/{workId}/applies/{applyId}","timestamp":"2025-08-19T14:00:00Z"}""")
                     )
@@ -201,5 +203,45 @@ public interface UserWorkApi {
             @Parameter(description = "조회할 지원서 ID", required = true, example = "10")
             @PathVariable Long applyId
     );
+
+    @Operation(
+            summary = "의뢰자 기준 수행자 승인",
+            description = "의뢰자가 자신이 등록한 일거리(taskId)에 지원한 수행자(performerId)를 승인하고 상태를 IN_PROGRESS로 변경합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "승인 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = WorkApplyListResDto.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                {"code":"REQUESTER_FORBIDDEN","message":"의뢰자 권한이 없습니다.","status":403,
+                                 "path":"/api/v1/tasks/{taskId}/approve/{performerId}","timestamp":"2025-08-19T14:00:00Z"}""")
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "해당 수행자 또는 일거리 없음",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ApiErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                {"code":"NOT_FOUND","message":"해당 수행자 또는 일거리를 찾을 수 없습니다.","status":404,
+                                 "path":"/api/v1/tasks/{taskId}/approve/{performerId}","timestamp":"2025-08-19T14:00:00Z"}""")
+                    )
+            )
+    })
+    @AllowedRoles(Role.REQUESTER)
+    @PostMapping("/{taskId}/approve/{performerId}")
+    ResponseEntity<WorkApplyListResDto> approvePerformer(
+            @Parameter(description = "요청자 역할 (REQUESTER)", required = true, example = "REQUESTER")
+            @RequestHeader("X-Role") String roleHeader,
+
+            @Parameter(description = "승인할 일거리 ID", required = true, example = "1")
+            @PathVariable Long taskId,
+
+            @Parameter(description = "승인할 수행자 ID", required = true, example = "10")
+            @PathVariable Long performerId
+    );
+
 }
 

--- a/src/main/java/com/ilkan/domain/entity/Work.java
+++ b/src/main/java/com/ilkan/domain/entity/Work.java
@@ -112,6 +112,8 @@ public class Work {
         this.workPhoneNumber = dto.getWorkPhoneNumber();
     }
 
+    public void updatePerformer(User performer){this.performer = performer;}
+
     public void updateStatus(Status status) {
         this.status = status;
     }
@@ -125,4 +127,6 @@ public class Work {
     }
 
     public void updateWorkCategory(WorkCategory workCategory) {this.workCategory = workCategory;}
+
+
 }

--- a/src/main/java/com/ilkan/dto/workdto/WorkApplyListResDto.java
+++ b/src/main/java/com/ilkan/dto/workdto/WorkApplyListResDto.java
@@ -9,8 +9,11 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-@Schema(description = "의뢰자 기준 수행자 일거리 지원목록 조회 DTO")
+@Schema(description = "의뢰자 기준 , 수행자 일거리 지원목록 조회 / 수행자 선택 DTO")
 public class WorkApplyListResDto {
+
+    @Schema(description = "수행자 ID", example = "42")
+    private final Long performerId;
 
     @Schema(description = "수행자명", example = "김야호")
     private final String performerName;
@@ -23,6 +26,7 @@ public class WorkApplyListResDto {
 
     public static WorkApplyListResDto fromEntity(TaskApplication application) {
         return WorkApplyListResDto.builder()
+                .performerId(application.getPerformerId().getId())
                 .performerName(application.getPerformerId().getName()) // 수행자 이름
                 .workTitle(application.getTaskId().getTitle())         // 일거리 제목
                 .portfolioUrl(application.getPortfolioUrl())           // 포트폴리오 URL

--- a/src/main/java/com/ilkan/repository/TaskApplicationRepository.java
+++ b/src/main/java/com/ilkan/repository/TaskApplicationRepository.java
@@ -1,13 +1,19 @@
 package com.ilkan.repository;
 
 import com.ilkan.domain.entity.TaskApplication;
+import com.ilkan.domain.entity.User;
+import com.ilkan.domain.entity.Work;
 import com.ilkan.domain.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TaskApplicationRepository extends JpaRepository<TaskApplication,Long> {
     Page<TaskApplication> findByPerformerId_IdAndStatus(Long performerId, Status status, Pageable pageable); // 수행자 자신이 지원한 일거리 내역조회
 
     Page<TaskApplication> findByTaskId_Requester_IdAndStatus(Long requesterId, Status status, Pageable pageable); // 의뢰자 기준 해당 일거리 지원서목록 조회
+
+    Optional<TaskApplication> findByTaskIdAndPerformerId(Work taskId, User performerId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- ILKAN-145

## 📝작업 내용

- 의뢰자가 수행자를 선택해야 매칭이 되기때문에 이 기능 구현
- 승인 시 해당 일거리 상태를 IN_PROGRESS로 변경
- 승인된 수행자 정보를 Work 엔티티에 반영
### 서비스계층
1. 권한 검증
2. 요청자 ID 매핑
3. 일거리 존재여부 확인
4. 일거리 소유자 검증
5. 수행자 조회 및 지원내역조회
6. 수행자 매칭 및 상태변경