### PR TITLE
fix : 예약 상태 자동 전환 스케줄러 수정

### DIFF
--- a/src/main/java/com/ilkan/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/ilkan/domain/reservation/repository/ReservationRepository.java
@@ -1,29 +1,22 @@
 package com.ilkan.domain.reservation.repository;
 
 import com.ilkan.domain.reservation.entity.Reservation;
+import com.ilkan.domain.reservation.entity.enums.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    @Query("""
-      select r from Reservation r
-      where r.reservationStatus = com.ilkan.domain.enums.ReservationStatus.RESERVED
-        and r.startTime <= :now and r.endTime > :now
-    """)
-    List<Reservation> findToInUse(@Param("now") LocalDateTime now);
+    List<Reservation> findAllByReservationStatusAndStartTimeLessThanEqualAndEndTimeGreaterThan(
+            ReservationStatus reservationStatus, LocalDateTime now1, LocalDateTime now2);
 
-    @Query("""
-      select r from Reservation r
-      where r.reservationStatus in (com.ilkan.domain.enums.ReservationStatus.RESERVED,
-                                    com.ilkan.domain.enums.ReservationStatus.IN_USE)
-        and r.endTime <= :now
-    """)
-    List<Reservation> findToComplete(@Param("now") LocalDateTime now);
+    List<Reservation> findAllByReservationStatusInAndEndTimeLessThanEqual(
+            Collection<ReservationStatus> statuses, LocalDateTime now);
 
     boolean existsByBuildingId_Id(Long buildingId);
 

--- a/src/main/java/com/ilkan/domain/reservation/scheduler/ReservationStatusScheduler.java
+++ b/src/main/java/com/ilkan/domain/reservation/scheduler/ReservationStatusScheduler.java
@@ -1,6 +1,7 @@
 package com.ilkan.domain.reservation.scheduler;
 
 import com.ilkan.domain.reservation.entity.Reservation;
+import com.ilkan.domain.reservation.entity.enums.ReservationStatus;
 import com.ilkan.domain.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -22,12 +23,17 @@ public class ReservationStatusScheduler {
     public void tick() {
         LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
-        // 1. IN_USE인 예약 목록 조회
-        List<Reservation> toInUse = reservationRepo.findToInUse(now);
+        // RESERVED → IN_USE
+        var toInUse = reservationRepo
+                .findAllByReservationStatusAndStartTimeLessThanEqualAndEndTimeGreaterThan(
+                        ReservationStatus.RESERVED, now, now);
         toInUse.forEach(Reservation::toInUse);
 
-        // 2. COMPLETE인 예약 목록 조회
-        List<Reservation> toComplete = reservationRepo.findToComplete(now);
+
+        // RESERVED/IN_USE → COMPLETE
+        var toComplete = reservationRepo
+                .findAllByReservationStatusInAndEndTimeLessThanEqual(
+                        List.of(ReservationStatus.RESERVED, ReservationStatus.IN_USE), now);
         toComplete.forEach(Reservation::toComplete);
     }
 }


### PR DESCRIPTION
## 📝작업 내용

- 예약 상태 자동 전환 스케줄러 수정
- ReservationRepository 쿼리 메서드 수정 (`@Query` enum 하드코딩 → 파라미터 방식)
- 스케줄러 실행 시점 기준으로 예약 상태 갱신 처리 추가
