### PR TITLE
[ILKAN-Fix] 일거리 전체조회 가능하게 오류수정

### DIFF
--- a/src/main/java/com/ilkan/domain/work/controller/WorksController.java
+++ b/src/main/java/com/ilkan/domain/work/controller/WorksController.java
@@ -40,7 +40,7 @@ public class WorksController implements WorksApi {
     // 카테고리별 일거리 조회 (category 필수)
     @GetMapping
     public ResponseEntity<Page<WorkListResDto>> getWorkList(
-            @RequestParam WorkCategory category, // 필수로 변경
+            @RequestParam(required = false) WorkCategory category, // 필수로 변경
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Page<WorkListResDto> worksList = workService.getWorkList(category, pageable);


### PR DESCRIPTION
## #️⃣연관된 이슈

ILKAN-Fix

## 📝작업 내용

- 기존: @RequestParam WorkCategory category 가 필수값으로 설정되어 있어 프론트에서 category를 전달하지 않으면 전체 조회 불가

- 변경: @RequestParam(required = false) 로 수정하여 category 미전달 시 null 처리

- 서비스 레벨에서 category == null 이면 findAll() 실행 → 전체 조회 동작

- category 값이 존재할 경우에는 기존처럼 필터링 조회 수행